### PR TITLE
Make some things configurable // fix some CREATE TABLE

### DIFF
--- a/ci-ctl/src/main.rs
+++ b/ci-ctl/src/main.rs
@@ -186,13 +186,13 @@ fn main() {
                         match remote_kind.as_str() {
                             "github" => {
                                 // attempt to create a webhook now...
-                                let (token, webhook_token) = match NotifierConfig::github_from_file(&full_config_file_path).expect("notifier config is valid") {
-                                    NotifierConfig::GitHub { token, webhook_token } => (token, webhook_token),
+                                let (ci_server, token, webhook_token) = match NotifierConfig::github_from_file(&full_config_file_path).expect("notifier config is valid") {
+                                    NotifierConfig::GitHub { ci_server, token, webhook_token } => (ci_server, token, webhook_token),
                                     _ => {
                                         panic!("unexpected notifier config format, should have been github..")
                                     }
                                 };
-                                let gh = GithubApi { token: &token, webhook_token: &webhook_token };
+                                let gh = GithubApi { ci_server: &ci_server, token: &token, webhook_token: &webhook_token };
                                 tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async move {
                                     match gh.has_ci_webhook(remote.as_str()).await {
                                         Ok(present) => {

--- a/ci-lib-core/src/sql.rs
+++ b/ci-lib-core/src/sql.rs
@@ -197,10 +197,10 @@ pub const CREATE_JOBS_TABLE: &'static str = "\
 
 pub const CREATE_METRICS_TABLE: &'static str = "\
     CREATE TABLE IF NOT EXISTS metrics (id INTEGER PRIMARY KEY AUTOINCREMENT,
-        job_id INTEGER,
+        run_id INTEGER,
         name TEXT,
         value TEXT,
-        UNIQUE(job_id, name)
+        UNIQUE(run_id, name)
     );";
 
 pub const CREATE_COMMITS_TABLE: &'static str = "\

--- a/ci-lib-core/src/sql.rs
+++ b/ci-lib-core/src/sql.rs
@@ -245,6 +245,7 @@ pub const CREATE_RUNS_TABLE: &'static str = "\
         job_id INTEGER,
         artifacts_path TEXT,
         state INTEGER NOT NULL,
+        host_preference INTEGER,
         host_id INTEGER,
         build_token TEXT,
         created_time INTEGER,

--- a/ci-lib-native/src/dbctx_ext.rs
+++ b/ci-lib-native/src/dbctx_ext.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::io::ArtifactDescriptor;
 use crate::notifier::{RemoteNotifier, NotifierConfig};
 
@@ -41,7 +43,7 @@ pub fn notifiers_by_repo(ctx: &DbCtx, repo_id: u64) -> Result<Vec<RemoteNotifier
     Ok(notifiers)
 }
 
-pub async fn reserve_artifact(ctx: &DbCtx, run_id: u64, name: &str, desc: &str) -> Result<ArtifactDescriptor, String> {
+pub async fn reserve_artifact(ctx: &DbCtx, artifact_path: PathBuf, run_id: u64, name: &str, desc: &str) -> Result<ArtifactDescriptor, String> {
     let artifact_id = {
         let created_time = ci_lib_core::now_ms();
         let conn = ctx.conn.lock().unwrap();
@@ -57,5 +59,5 @@ pub async fn reserve_artifact(ctx: &DbCtx, run_id: u64, name: &str, desc: &str) 
         conn.last_insert_rowid() as u64
     };
 
-    ArtifactDescriptor::new(run_id, artifact_id).await
+    ArtifactDescriptor::new(artifact_path, run_id, artifact_id).await
 }

--- a/ci-lib-native/src/dbctx_ext.rs
+++ b/ci-lib-native/src/dbctx_ext.rs
@@ -3,7 +3,7 @@ use crate::notifier::{RemoteNotifier, NotifierConfig};
 
 use ci_lib_core::dbctx::DbCtx;
 
-pub fn notifiers_by_repo(ctx: &DbCtx, repo_id: u64) -> Result<Vec<RemoteNotifier>, String> {
+pub fn notifiers_by_repo(ctx: &DbCtx, ci_host: &str, repo_id: u64) -> Result<Vec<RemoteNotifier>, String> {
     let remotes = ctx.remotes_by_repo(repo_id)?;
 
     let mut notifiers: Vec<RemoteNotifier> = Vec::new();
@@ -15,6 +15,7 @@ pub fn notifiers_by_repo(ctx: &DbCtx, repo_id: u64) -> Result<Vec<RemoteNotifier
                 notifier_path.push(&remote.notifier_config_path);
 
                 let notifier = RemoteNotifier {
+                    ci_host: ci_host.to_owned(),
                     remote_path: remote.remote_path,
                     notifier: NotifierConfig::github_from_file(&notifier_path)
                         .expect("can load notifier config")
@@ -26,6 +27,7 @@ pub fn notifiers_by_repo(ctx: &DbCtx, repo_id: u64) -> Result<Vec<RemoteNotifier
                 notifier_path.push(&remote.notifier_config_path);
 
                 let notifier = RemoteNotifier {
+                    ci_host: ci_host.to_owned(),
                     remote_path: remote.remote_path,
                     notifier: NotifierConfig::email_from_file(&notifier_path)
                         .expect("can load notifier config")

--- a/ci-lib-native/src/dbctx_ext.rs
+++ b/ci-lib-native/src/dbctx_ext.rs
@@ -3,7 +3,7 @@ use crate::notifier::{RemoteNotifier, NotifierConfig};
 
 use ci_lib_core::dbctx::DbCtx;
 
-pub fn notifiers_by_repo(ctx: &DbCtx, ci_host: &str, repo_id: u64) -> Result<Vec<RemoteNotifier>, String> {
+pub fn notifiers_by_repo(ctx: &DbCtx, repo_id: u64) -> Result<Vec<RemoteNotifier>, String> {
     let remotes = ctx.remotes_by_repo(repo_id)?;
 
     let mut notifiers: Vec<RemoteNotifier> = Vec::new();
@@ -15,7 +15,6 @@ pub fn notifiers_by_repo(ctx: &DbCtx, ci_host: &str, repo_id: u64) -> Result<Vec
                 notifier_path.push(&remote.notifier_config_path);
 
                 let notifier = RemoteNotifier {
-                    ci_host: ci_host.to_owned(),
                     remote_path: remote.remote_path,
                     notifier: NotifierConfig::github_from_file(&notifier_path)
                         .expect("can load notifier config")
@@ -27,7 +26,6 @@ pub fn notifiers_by_repo(ctx: &DbCtx, ci_host: &str, repo_id: u64) -> Result<Vec
                 notifier_path.push(&remote.notifier_config_path);
 
                 let notifier = RemoteNotifier {
-                    ci_host: ci_host.to_owned(),
                     remote_path: remote.remote_path,
                     notifier: NotifierConfig::email_from_file(&notifier_path)
                         .expect("can load notifier config")

--- a/ci-lib-native/src/io.rs
+++ b/ci-lib-native/src/io.rs
@@ -2,6 +2,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use futures_util::StreamExt;
 use tokio::fs::File;
 use tokio::fs::OpenOptions;
+use std::path::PathBuf;
 use std::task::{Poll, Context};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -97,16 +98,15 @@ pub struct ArtifactDescriptor {
 }
 
 impl ArtifactDescriptor {
-    pub async fn new(job_id: u64, artifact_id: u64) -> Result<Self, String> {
-        // TODO: jobs should be a configurable path
-        let path = format!("artifacts/{}/{}", job_id, artifact_id);
+    pub async fn new(artifact_path: PathBuf, job_id: u64, artifact_id: u64) -> Result<Self, String> {
+        let path = artifact_path.join(format!("{}/{}", job_id, artifact_id));
         let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create_new(true)
             .open(&path)
             .await
-            .map_err(|e| format!("couldn't open artifact file {}: {}", path, e))?;
+            .map_err(|e| format!("couldn't open artifact file {}: {}", path.to_string_lossy(), e))?;
 
         Ok(ArtifactDescriptor {
             job_id,

--- a/ci-lib-native/src/notifier.rs
+++ b/ci-lib-native/src/notifier.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use ci_lib_core::dbctx::DbCtx;
 
 pub struct RemoteNotifier {
+    pub ci_host: String,
     pub remote_path: String,
     pub notifier: NotifierConfig,
 }
@@ -66,7 +67,7 @@ impl RemoteNotifier {
         self.tell_job_status(
             ctx,
             repo_id, sha, job_id,
-            "pending", "build is queued", &format!("https://{}/{}/{}", "ci.butactuallyin.space", &self.remote_path, sha)
+            "pending", "build is queued", &format!("https://{}/{}/{}", &self.ci_host, &self.remote_path, sha)
         ).await
     }
 
@@ -76,14 +77,14 @@ impl RemoteNotifier {
                 self.tell_job_status(
                     ctx,
                     repo_id, sha, job_id,
-                    "success", &status, &format!("https://{}/{}/{}", "ci.butactuallyin.space", &self.remote_path, sha)
+                    "success", &status, &format!("https://{}/{}/{}", &self.ci_host, &self.remote_path, sha)
                 ).await
             },
             Err(status) => {
                 self.tell_job_status(
                     ctx,
                     repo_id, sha, job_id,
-                    "failure", &status, &format!("https://{}/{}/{}", "ci.butactuallyin.space", &self.remote_path, sha)
+                    "failure", &status, &format!("https://{}/{}/{}", &self.ci_host, &self.remote_path, sha)
                 ).await
             }
         }

--- a/ci-lib-web/src/lib.rs
+++ b/ci-lib-web/src/lib.rs
@@ -60,7 +60,7 @@ pub fn commit_url(job: &Job, commit_sha: &str, ctx: &Arc<DbCtx>) -> (String, Opt
     }
 }
 
-/// produce a url to the ci.butactuallyin.space job details page
+/// produce a url to the job details page
 pub fn job_url(job: &Job, commit_sha: &str, ctx: &Arc<DbCtx>) -> String {
     let remote = ctx.remote_by_id(job.remote_id).expect("query succeeds").expect("existing job references existing remote");
 

--- a/ci-web-server/src/main.rs
+++ b/ci-web-server/src/main.rs
@@ -4,7 +4,6 @@
 
 use chrono::{Utc, TimeZone};
 use lazy_static::lazy_static;
-use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
@@ -67,8 +66,6 @@ struct GithubPsk {
 lazy_static! {
     static ref PSKS: RwLock<Vec<GithubPsk>> = RwLock::new(Vec::new());
 }
-
-static SERVER_HOST: OnceLock<String> = OnceLock::new();
 
 #[derive(Copy, Clone, Debug)]
 enum GithubHookError {
@@ -187,8 +184,7 @@ async fn process_push_event(ctx: Arc<DbCtx>, owner: String, repo: String, event:
             // at this point we have a commit id, record the ref..
             let _ = ctx.new_run(job_id, None).unwrap();
             
-            let host = SERVER_HOST.get().expect("server host was set");
-            let notifiers = ci_lib_native::dbctx_ext::notifiers_by_repo(&ctx, host, repo_id).expect("can get notifiers");
+            let notifiers = ci_lib_native::dbctx_ext::notifiers_by_repo(&ctx, repo_id).expect("can get notifiers");
 
             for notifier in notifiers {
                 notifier.tell_pending_job(&ctx, repo_id, &sha, job_id).await.expect("can notify");
@@ -880,8 +876,6 @@ async fn main() {
     *psks = web_config.psks.clone();
     // drop write lock so we can read PSKS elsewhere WITHOUT deadlocking.
     std::mem::drop(psks);
-
-    SERVER_HOST.set(web_config.server_host.clone());
 
     let jobs_path = web_config.jobs_path.clone();
     let config_path = web_config.config_path.clone();


### PR DESCRIPTION
This is a cute little thing, build-o-tron.

Adds some config keys:
- `server_host` for `ci-web-server` so it can correctly set the host in the HTML.
- `artifact_path` for `ci-web-server` so the path artifacts live is not fixed to `./artifact`
- `artifact_path` to `ci-driver` for the same reason.
- `ci_server` to the Email and Github configs. Currently email's is unused, so maybe I should remove it?

Does some stuff to the SQL create tables because I was getting yelled at for some columns that did not exist:
- in the metric table i changed `job_id` to `run_id`. I am unsure if this is correct? Is it a new column, or was the column renamed?
- added the `host_preference` column to the runs table.

Notably I did not change the domain that the SMTP client identifies as when sending email. That is still `ci.butactuallyin.space`. Should I change it? I also left the user-agent alone. Maybe it should be `build-o-tron`?

Let me know if you want any changes